### PR TITLE
Lots of changes.

### DIFF
--- a/examples/PEs/PE_lut/isa.py
+++ b/examples/PEs/PE_lut/isa.py
@@ -10,6 +10,7 @@ def gen_isa(width):
         imm = 1
         Add = 2
         Mux = 6
+        isub=7
 
     @family_closure
     def isa_fc(family):

--- a/examples/PEs/PE_lut/sim.py
+++ b/examples/PEs/PE_lut/sim.py
@@ -20,8 +20,10 @@ def gen_sub_modules(width):
                     res = alu_inst.imm
                 elif op == OP.Add:
                     res = a + b
-                else: # op == OP.Mux:
+                elif op == OP.Mux:
                     res = d.ite(a, b)
+                else:
+                    res = alu_inst.imm - a
                 return res
 
         @family.assemble(locals(), globals())

--- a/examples/coreir/add3.json
+++ b/examples/coreir/add3.json
@@ -1,0 +1,33 @@
+{"top":"global.Add3",
+"namespaces":{
+  "global":{
+    "modules":{
+      "Add3":{
+        "type":["Record",[
+          ["in0",["Array",16,"BitIn"]],
+          ["in1",["Array",16,"BitIn"]],
+          ["in2",["Array",16,"BitIn"]],
+          ["out",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "add0":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          },
+          "add1":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          }
+        },
+        "connections":[
+          ["self.in0","add0.in0"],
+          ["self.in1","add0.in1"],
+          ["add1.in0","add0.out"],
+          ["self.in2","add1.in1"],
+          ["self.out","add1.out"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/examples/coreir/pipe.json
+++ b/examples/coreir/pipe.json
@@ -1,0 +1,29 @@
+{"top":"global.Add2",
+"namespaces":{
+  "global":{
+    "modules":{
+      "Add2":{
+        "type":["Record",[
+          ["in0",["Array",16,"BitIn"]],
+          ["out",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "r0": {
+            "genref": "coreir.reg",
+            "genargs": {"width":["Int", 16]}
+          },
+          "r1": {
+            "genref": "coreir.reg",
+            "genargs": {"width":["Int", 16]}
+          }
+        },
+        "connections":[
+          ["self.in0","r0.in"],
+          ["r0.out","r1.in"],
+          ["self.out","r1.out"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/metamapper/common_passes.py
+++ b/metamapper/common_passes.py
@@ -116,15 +116,15 @@ class VerifyNodes(Visitor):
         return None
 
     def generic_visit(self, node):
-        nodes = type(node).nodes
-        if nodes != self.nodes and nodes != Common:
-            self.wrong_nodes.add(node)
+        if node.node_name != "coreir.reg":
+            nodes = type(node).nodes
+            if nodes != self.nodes and nodes != Common:
+                self.wrong_nodes.add(node)
         Visitor.generic_visit(self, node)
 
 from peak.mapper.utils import rebind_type, solved_to_bv
 import pysmt.shortcuts as smt
 from pysmt.logics import QF_BV
-
 
 def prove_formula(formula, solver, i1):
     with smt.Solver(solver, logic=QF_BV) as solver:
@@ -211,7 +211,6 @@ class SMT(Visitor):
         self.values[node] = output_val
 
 
-
 class AddID(Visitor):
     def __init__(self):
         self.curid = 0
@@ -244,6 +243,9 @@ class Printer(Visitor):
         Visitor.generic_visit(self, node)
         self.res += f"{node._id_}<Input>\n"
 
+    def visit_InstanceInput(self, node):
+        self.res += f"{node._id_}<InstanceInput>\n"
+
     def visit_Constant(self, node):
         self.res += f"{node._id_}<Constant>({node.value}{type(node.value)}, {node.type})>\n"
 
@@ -251,6 +253,11 @@ class Printer(Visitor):
         Visitor.generic_visit(self, node)
         child_ids = ", ".join([str(child._id_) for child in node.children()])
         self.res += f"{node._id_}<Output>({child_ids})\n"
+
+    def visit_InstanceOutput(self, node):
+        Visitor.generic_visit(self, node)
+        child_ids = ", ".join([str(child._id_) for child in node.children()])
+        self.res += f"{node._id_}<InstanceOutput>({child_ids})\n"
 
     def visit_Combine(self, node: Bind):
         Visitor.generic_visit(self, node)

--- a/metamapper/coreir_mapper.py
+++ b/metamapper/coreir_mapper.py
@@ -1,51 +1,73 @@
-from metamapper.common_passes import VerifyNodes, print_dag, SimplifyCombines, RemoveSelects, prove_equal, Clone
+from metamapper.common_passes import VerifyNodes, print_dag, SimplifyCombines, RemoveSelects, prove_equal, Clone, ExtractNames
 import metamapper.coreir_util as cutil
 from metamapper.rewrite_table import RewriteTable
-from metamapper.node import Nodes
+from metamapper.node import Nodes, Dag
 from metamapper.instruction_selection import GreedyCovering
-from peak.mapper import RewriteRule as PeakRule
+from peak.mapper import RewriteRule as PeakRule, read_serialized_bindings
 import typing as tp
 import coreir
+import json
+
+#conv_ops = (
+#    "corebit.const",
+#    "coreir.add",
+#    "coreir.mul",
+#    "coreir.const",
+#)
+#camera_ops = (
+#    "corebit.const",
+#    "corebit.or_",
+#    "corebit.and_",
+#    "coreir.add",
+#    "coreir.and_",
+#    "coreir.ashr",
+#    "coreir.const",
+#    "coreir.eq",
+#    "coreir.lshr",
+#    "coreir.mul",
+#    "coreir.mux",
+#    "coreir.slt",
+#    "coreir.sub",
+#    "coreir.ult",
+#    "commonlib.abs",
+#    "commonlib.smax",
+#    "commonlib.smin",
+#    "commonlib.umax",
+#    "commonlib.umin",
+#)
+
 
 class Mapper:
-    def __init__(self, CoreIRNodes: Nodes, ArchNodes: Nodes, alg=GreedyCovering, peak_rules: tp.List[PeakRule]=None, conv=True):
+    # Lazy # Discover at mapping time
+    # ops (if lazy=False, search for these)
+    # rule_file #pointer to serialized rule file
+    def __init__(self, CoreIRNodes: Nodes, ArchNodes: Nodes, alg=GreedyCovering, lazy=True, ops=[], rule_file=None):
+
         self.CoreIRNodes = CoreIRNodes
         self.ArchNodes = ArchNodes
         self.table = RewriteTable(CoreIRNodes, ArchNodes)
-        conv_ops = (
-            "corebit.const",
-            "coreir.add",
-            "coreir.mul",
-            "coreir.const",
-        )
-        camera_ops = (
-            "corebit.const",
-            "corebit.or_",
-            "corebit.and_",
-            "coreir.add",
-            "coreir.and_",
-            "coreir.ashr",
-            "coreir.const",
-            "coreir.eq",
-            "coreir.lshr",
-            "coreir.mul",
-            "coreir.mux",
-            "coreir.slt",
-            "coreir.sub",
-            "coreir.ult",
-            "commonlib.abs",
-            "commonlib.smax",
-            "commonlib.smin",
-            "commonlib.umax",
-            "commonlib.umin",
-        )
-        if peak_rules is None:
-            for node_name in ArchNodes._node_names:
-                #auto discover the rules for CoreIR
-                if conv:
-                    ops = conv_ops
-                else:
-                    ops = camera_ops
+
+        if not lazy and rule_file is None and len(ops) == 0:
+            raise ValueError("If not lazy, need ops specified!")
+        if lazy and len(ops) > 0:
+            raise ValueError("if lazy, needs no ops specified!")
+
+        if not lazy:
+            self.gen_rules(ops, rule_file)
+            self.compile_time_rule_gen = lambda dag : None
+        else:
+            def lazy_rule_gen(dag: Dag):
+                op_dict = ExtractNames(self.CoreIRNodes).extract(dag)
+                ops = list(op_dict.keys())
+                self.gen_rules(ops, rule_file)
+            self.compile_time_rule_gen = lazy_rule_gen
+
+        self.inst_sel = alg(self.table)
+
+    def gen_rules(self, ops, rule_file=None):
+        if rule_file is None:
+            for node_name in self.ArchNodes._node_names:
+                # auto discover the rules for CoreIR
                 for op in ops:
                     peak_rule = self.table.discover(op, node_name)
                     print(f"Searching for {op} -> {node_name}")
@@ -55,38 +77,48 @@ class Mapper:
                     else:
                         print(f"  Found!")
         else:
-            #load the rules
-            for peak_rule in peak_rules:
-                self.table.add_peak_rule(peak_rule)
-        self.inst_sel = alg(self.table)
+            for arch_name in self.ArchNodes._node_names:
+                arch_fc = self.ArchNodes.peak_nodes[arch_name]
+                with open(rule_file, "r") as read_file:
+                    rrs = json.loads(read_file.read())
+                    for op in ops:
+                        ir_fc = self.CoreIRNodes.peak_nodes[op]
+                        new_rewrite_rule = read_serialized_bindings(rrs[op], ir_fc, arch_fc)
+                        counter_example = new_rewrite_rule.verify()
 
-    def do_mapping(self, pb_dags, convert_unbound=True) -> coreir.Module:
+                    if counter_example is not None:
+                        print(counter_example)
+                        raise ValueError(f"RR for {op} fails with ^ Counter Example")
+                    self.table.add_peak_rule(new_rewrite_rule)
+
+    def do_mapping(self, dag, convert_unbound=True, prove_mapping=True) -> coreir.Module:
         #Preprocess isolates coreir primitive modules
         #inline inlines them back in
-        if len(pb_dags) != 1:
-            raise ValueError(f"Bad: {len(pb_dags)}")
-        for inst, dag in pb_dags.items():
-            #print("premapped")
-            #print_dag(dag)
-            original_dag = Clone().clone(dag, iname_prefix=f"original_")
-            mapped_dag = self.inst_sel(dag)
-            #print("postmapped")
-            #print_dag(mapped_dag)
-            SimplifyCombines().run(mapped_dag)
-            #print("simplifyCombines")
-            #print_dag(mapped_dag)
-            RemoveSelects().run(mapped_dag)
-            #print("RemovedSelects")
-            #print_dag(mapped_dag)
-            unmapped = VerifyNodes(self.ArchNodes).verify(mapped_dag)
-            if unmapped is not None:
-                raise ValueError(f"Following nodes were unmapped: {unmapped}")
-            assert VerifyNodes(self.CoreIRNodes).verify(original_dag) is None
+        #print("premapped")
+        #print_dag(dag)
+        self.compile_time_rule_gen(dag)
+        original_dag = Clone().clone(dag, iname_prefix=f"original_")
+
+        mapped_dag = self.inst_sel(dag)
+        #print("postmapped")
+        #print_dag(mapped_dag)
+        SimplifyCombines().run(mapped_dag)
+        #print("simplifyCombines")
+        #print_dag(mapped_dag)
+        RemoveSelects().run(mapped_dag)
+        #print("RemovedSelects")
+        #print_dag(mapped_dag)
+        unmapped = VerifyNodes(self.ArchNodes).verify(mapped_dag)
+        if unmapped is not None:
+            raise ValueError(f"Following nodes were unmapped: {unmapped}")
+        assert VerifyNodes(self.CoreIRNodes).verify(original_dag) is None
+        if prove_mapping:
             counter_example = prove_equal(original_dag, mapped_dag)
             if counter_example is not None:
                 raise ValueError(f"Mapped is not the same {counter_example}")
-            #Create a new module representing the mapped_dag
-            mapped_mod = cutil.dag_to_coreir_def(self.ArchNodes, mapped_dag, inst.module, inst.module.name + "_mapped")
-            #coreir.inline_instance(inst)
-            return mapped_mod
+        #Create a new module representing the mapped_dag
+        return mapped_dag
+        #mapped_mod = cutil.dag_to_coreir_def(self.ArchNodes, mapped_dag, inst.module, inst.module.name + "_mapped")
+        ##coreir.inline_instance(inst)
+        #return mapped_mod
         #cmod should now contain a mapped coreir module

--- a/metamapper/irs/coreir/__init__.py
+++ b/metamapper/irs/coreir/__init__.py
@@ -38,5 +38,11 @@ def gen_CoreIRNodes(width):
             assert CoreIRNodes.name_from_coreir(cmod) == name
             print(f"Loaded {name}!")
 
+    #Load reg
+    name = f"coreir.reg"
+    peak_fc = peak_ir.instructions[name]
+    cmod = c.get_namespace("coreir").generators["reg"](width=width)
+    name_ = load_from_peak(CoreIRNodes, peak_fc, cmod=cmod, name="coreir.reg", stateful=True, modparams=("clk_posedge", "init"))
+
     return CoreIRNodes
 

--- a/metamapper/irs/coreir/ir.py
+++ b/metamapper/irs/coreir/ir.py
@@ -102,13 +102,30 @@ def gen_peak_CoreIR(width):
 
     CoreIR.add_instruction("corebit.const", constBit_fc)
 
+    @family_closure
+    def reg_fc(family):
+        Data = family.BitVector[width]
+        Bit = family.Bit
+        class reg(Peak):
+            def __init__(self):
+                self.value = Data(0)
+
+            @name_outputs(out=Data)
+            def __call__(self, in___: Data, clk_posedge: Const(Bit), init: Const(Data)) -> Data:
+                value = self.value
+                self.value = in___
+                return value
+        return reg
+
+    CoreIR.add_instruction("coreir.reg", reg_fc)
+
 
 
     class UnaryInput(Product):
-        in0 = BitVector[width]
+        in___ = BitVector[width]
 
     class UnaryInputBit(Product):
-        in0=Bit
+        in___=Bit
 
     class BinaryInput(Product):
         in0=BitVector[width]

--- a/metamapper/rewrite_table.py
+++ b/metamapper/rewrite_table.py
@@ -1,3 +1,5 @@
+from functools import lru_cache
+
 from hwtypes.modifiers import strip_modifiers
 from .common_passes import CheckIfTree, VerifyNodes, print_dag, BindsToCombines, SimplifyCombines, RemoveSelects
 import typing as tp
@@ -67,7 +69,7 @@ class RewriteTable:
         to_node_t = self.to.dag_nodes[to_node_name]
         assert issubclass(to_node_t, DagNode)
         to_bv = to_fc(fam().PyFamily())
-        to_input = Input(iname="self", type=from_bv.input_t)
+        to_input = Input(iname="self", type=strip_modifiers(from_bv.input_t))
 
         def sel_from(path, node: DagNode):
             assert isinstance(path, tuple)

--- a/tests/_test_simple_example.py
+++ b/tests/_test_simple_example.py
@@ -29,7 +29,6 @@ def test_peak_to_node(args):
             imm=Data
         @family.assemble(globals(), locals())
         class FMA(Peak):
-            @name_outputs(out=Data)
             def __call__(self, config: Const(Config), a:Data, b:Data) -> Data:
                 return a*config.imm + b
         return FMA
@@ -47,8 +46,8 @@ def test_peak_to_node(args):
     in1 = input_node.select("in1")
     in2 = input_node.select("in2")
     fma1 = FMANode(Constant(value=BV16(5), type=BV16), in0, in1)
-    fma2 = FMANode(Constant(value=BV16(2), type=BV16), in2, fma1.select("out"))
-    output_node = Output(fma2.select("out"), type=output_type)
+    fma2 = FMANode(Constant(value=BV16(2), type=BV16), in2, fma1.select(0))
+    output_node = Output(fma2.select(0), type=output_type)
     dag = Dag(sources=[input_node], sinks=[output_node])
 
     #You can print the dag

--- a/tests/test_coreir_util.py
+++ b/tests/test_coreir_util.py
@@ -28,6 +28,7 @@ full_apps = [
     #"camera_pipeline"
 ]
 
+@pytest.mark.skip
 @pytest.mark.parametrize("name", full_apps)
 def test_apps(name):
     c = CoreIRContext(reset=True)

--- a/tests/test_coreir_util.py
+++ b/tests/test_coreir_util.py
@@ -1,11 +1,40 @@
 import metamapper.coreir_util as cutil
-from metamapper.common_passes import VerifyNodes
+from metamapper.common_passes import VerifyNodes, print_dag
 from metamapper import CoreIRContext
 from metamapper.irs.coreir import gen_CoreIRNodes
+import pytest
 
-def test_coreir_to_dag():
-    CoreIRContext(reset=True)
+examples_coreir = [
+    "add4_pipe",
+    "add2",
+    "pipe",
+    "add1_const",
+    "add3",
+    "add4",
+    "add3_const"
+]
+
+@pytest.mark.parametrize("name", examples_coreir)
+def test_examples_coreir(name):
+    c = CoreIRContext(reset=True)
+    file_name = f"examples/coreir/{name}.json"
     CoreIRNodes = gen_CoreIRNodes(16)
-    cmod = cutil.load_from_json("examples/coreir/add4.json")
+    cmod = cutil.load_from_json(file_name)
     dag = cutil.coreir_to_dag(CoreIRNodes, cmod)
-    VerifyNodes(CoreIRNodes).run(dag)
+    print_dag(dag)
+
+full_apps = [
+    "conv_3_3",
+    #"camera_pipeline"
+]
+
+@pytest.mark.parametrize("name", full_apps)
+def test_apps(name):
+    c = CoreIRContext(reset=True)
+    file_name = f"apps/{name}.json"
+    CoreIRNodes = gen_CoreIRNodes(16)
+    cmod = cutil.load_from_json(file_name, libraries=["commonlib", "lakelib"])
+    dag = cutil.coreir_to_dag(CoreIRNodes, cmod)
+    cmod.print_()
+    print_dag(dag)
+

--- a/tests/test_rewrite_table.py
+++ b/tests/test_rewrite_table.py
@@ -137,6 +137,7 @@ def test_complex_dag():
     print_dag(mapped_dag)
     verify_and_print(ArchNodes, mapped_dag)
 
+@pytest.mark.skip
 def test_complex_dag_const():
     CoreIRContext(reset=True)
     arch_fc = gen_Add3(16)


### PR DESCRIPTION
 Can load any CoreIR file now without hacking the isolate primitives. Added ability to load instances, registers and
memories as arbitrary state. Fixed typing of metamapper. Modified API
for mapping to be able to load serialized rules.